### PR TITLE
delta checksum verification is disabled by default, for better performance

### DIFF
--- a/fossil-delta.js
+++ b/fossil-delta.js
@@ -53,7 +53,9 @@
 })(this, function() {
 'use strict';
 
-var fossilDelta = {};
+var fossilDelta = {
+  ENABLE_CHECKSUM: false
+};
 
 // Hash window width in bytes. Must be a power of two.
 var NHASH = 16;
@@ -432,7 +434,7 @@ fossilDelta.apply = function(src, delta) {
 
       case ';':
         var out = zOut.toArray();
-        if (cnt !== checksum(out))
+        if (fossilDelta.ENABLE_CHECKSUM && cnt !== checksum(out))
           throw new Error('bad checksum');
         if (total !== limit)
           throw new Error('generated size does not match predicted size');

--- a/fossil-delta.js
+++ b/fossil-delta.js
@@ -432,7 +432,7 @@ fossilDelta.apply = function(src, delta, opts) {
 
       case ';':
         var out = zOut.toArray();
-        if (opts && opts.verifyChecksum && cnt !== checksum(out))
+        if ((!opts || opts.verifyChecksum !== false) && cnt !== checksum(out))
           throw new Error('bad checksum');
         if (total !== limit)
           throw new Error('generated size does not match predicted size');

--- a/fossil-delta.js
+++ b/fossil-delta.js
@@ -53,9 +53,7 @@
 })(this, function() {
 'use strict';
 
-var fossilDelta = {
-  ENABLE_CHECKSUM: false
-};
+var fossilDelta = {};
 
 // Hash window width in bytes. Must be a power of two.
 var NHASH = 16;
@@ -395,7 +393,7 @@ fossilDelta.outputSize = function(delta){
 };
 
 // Apply a delta.
-fossilDelta.apply = function(src, delta) {
+fossilDelta.apply = function(src, delta, opts) {
   var limit, total = 0;
   var zDelta = new Reader(delta);
   var lenSrc = src.length;
@@ -434,7 +432,7 @@ fossilDelta.apply = function(src, delta) {
 
       case ';':
         var out = zOut.toArray();
-        if (fossilDelta.ENABLE_CHECKSUM && cnt !== checksum(out))
+        if (opts && opts.verifyChecksum && cnt !== checksum(out))
           throw new Error('bad checksum');
         if (total !== limit)
           throw new Error('generated size does not match predicted size');


### PR DESCRIPTION
The latest version of Fossil's Delta algorithm has disabled checksum during `apply` method. (See: http://fossil-scm.org/xfer/info/d3a46b2a45b92bbc)

Here's [my benchmark results](https://gist.github.com/endel/676a24b8b5cde3900b6d6a2187a890f8) for applying the delta on the 5 test scenarios:

```
with checksum x 10,960 ops/sec ±1.50% (87 runs sampled)
without checksum x 12,438 ops/sec ±1.46% (85 runs sampled)
```

Cheers!